### PR TITLE
Dev

### DIFF
--- a/app/conda/docker-compose.yml
+++ b/app/conda/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.5'
 services:
   miniconda3_25:
     image: minconda:local

--- a/app/julia/docker-compose.yml
+++ b/app/julia/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.5'
 services:
   julia:
     image: julia:local

--- a/backup/README.md
+++ b/backup/README.md
@@ -1,0 +1,86 @@
+1. usar **LVM real** (volúmenes lógicos),
+2. usar un **archivo .img en loop** (que se comporta como un “disco” pero sin crear particiones reales).
+
+Las dos son válidas; la primera es más empresarial, la segunda es más simple. A continuación, ambas.
+
+---
+
+## 1. Con **LVM real** (volúmenes lógicos)
+
+Aquí no usas `.img`. Creas un volumen lógico con tamaño fijo y lo formateas.
+
+### Pasos típicos
+
+**1. Crear un volumen lógico**
+
+```bash
+lvcreate -L 5G -n docker_vol vg0
+```
+
+* `vg0`: tu *volume group*.
+* `5G`: tamaño exacto y limitado.
+
+**2. Formatearlo**
+
+```bash
+mkfs.ext4 /dev/vg0/docker_vol
+```
+
+**3. Crear un punto de montaje**
+
+```bash
+mkdir -p /mnt/docker_vol
+```
+
+**4. Montarlo**
+
+```bash
+mount /dev/vg0/docker_vol /mnt/docker_vol
+```
+
+**5. Usarlo como volumen en Docker**
+
+```bash
+docker run -v /mnt/docker_vol:/data imagen
+```
+
+Resultado: el directorio `/data` dentro del contenedor **no puede superar 5 GB**, porque el volumen lógico aplicado al host lo limita de forma estricta.
+
+---
+
+## 2. Con **archivo `.img` tipo loop** (sin particiones reales)
+
+Esto es útil si no quieres tocar LVM ni crear particiones.
+Crea un archivo que actúa como disco virtual.
+
+### Pasos
+
+**1. Crear archivo con tamaño fijo**
+
+```bash
+truncate -s 5G /opt/docker_vol.img
+```
+
+**2. Formatearlo**
+
+```bash
+mkfs.ext4 /opt/docker_vol.img
+```
+
+**3. Montarlo usando loop**
+
+```bash
+mkdir -p /mnt/docker_vol
+mount -o loop docker_vol.img /mnt/docker_vol
+umount /mnt/docker_vol
+sudo losetup -D
+```
+
+**4. Usarlo en Docker**
+
+```bash
+docker run --rm -it -v /mnt/docker_vol:/opt/data alpine:3.20 sh
+df -h /opt/data
+```
+
+El límite lo impone el tamaño del archivo `.img`.

--- a/backup/README.md
+++ b/backup/README.md
@@ -1,86 +1,279 @@
-1. usar **LVM real** (volúmenes lógicos),
-2. usar un **archivo .img en loop** (que se comporta como un “disco” pero sin crear particiones reales).
+## Almacenamiento portable con límite estricto de tamaño
 
-Las dos son válidas; la primera es más empresarial, la segunda es más simple. A continuación, ambas.
+**LVM real vs archivo `.img` en loop**
 
 ---
 
-## 1. Con **LVM real** (volúmenes lógicos)
+## 1) Objetivo
 
-Aquí no usas `.img`. Creas un volumen lógico con tamaño fijo y lo formateas.
+Definir y ejecutar un mecanismo de **almacenamiento portable con límite de capacidad estrictamente controlado**, utilizable como volumen de Docker o como punto de montaje en Linux, eligiendo entre:
 
-### Pasos típicos
+* **LVM real** (volúmenes lógicos en el host).
+* **Archivo `.img` montado por loop** (disco virtual portable).
 
-**1. Crear un volumen lógico**
+El objetivo es garantizar:
+
+* **Límite duro de espacio** (hard cap).
+* **Comportamiento predecible** bajo carga.
+* **Reproducibilidad y auditabilidad** del montaje.
+
+---
+
+## 2) Modelos disponibles (decisión arquitectónica)
+
+### Opción A — LVM real (volúmenes lógicos)
+
+**Perfil**
+
+* Entornos productivos
+* Infraestructura administrada
+* Host con LVM ya configurado
+
+**Características**
+
+* Límite real a nivel de bloque
+* Mayor robustez
+* Menor portabilidad entre hosts
+
+---
+
+### Opción B — Archivo `.img` en loop
+
+**Perfil**
+
+* Desarrollo
+* Portabilidad entre sistemas
+* Hosts sin LVM o sin permisos elevados
+
+**Características**
+
+* Disco virtual autocontenido
+* Fácil copia, backup y migración
+* Rendimiento ligeramente inferior
+
+---
+
+## 3) Inputs (parámetros controlados)
+
+### 3.1 Parámetros comunes
+
+* **Tamaño objetivo**: p. ej. `5G`
+* **Sistema de archivos**: `ext4`
+* **Punto de montaje**: `/mnt/docker_vol`
+* **Uso previsto**: volumen Docker (`-v host:container`)
+
+---
+
+### 3.2 Inputs específicos
+
+#### LVM
+
+* Volume Group existente (ej.: `vg0`)
+* Permisos root
+* LVM activo en el sistema
+
+#### `.img`
+
+* Ruta del archivo (ej.: `/opt/docker_vol.img`)
+* Espacio disponible en el filesystem host
+* Soporte de loop devices (`losetup`)
+
+---
+
+## 4) Equipamiento mínimo (dependencias)
+
+* Linux con soporte ext4
+* `mount`, `mkfs.ext4`
+* Docker
+* Para LVM: `lvm2`
+* Para `.img`: soporte loop (`losetup`)
+
+---
+
+## 5) Condiciones previas (pre-flight)
+
+1. Confirmar espacio suficiente en el host.
+2. Definir tamaño **antes** de crear el volumen (no dinámico).
+3. Confirmar que el punto de montaje no esté en uso.
+4. Verificar permisos root.
+5. Detener contenedores que puedan reutilizar el path.
+
+---
+
+## 6) Flujo de ejecución — Opción A: **LVM real**
+
+### Estado A1 — Creación del volumen lógico
 
 ```bash
 lvcreate -L 5G -n docker_vol vg0
 ```
 
-* `vg0`: tu *volume group*.
-* `5G`: tamaño exacto y limitado.
+**Resultado esperado**
 
-**2. Formatearlo**
+* `/dev/vg0/docker_vol` existe
+* Tamaño fijo e inmutable salvo resize explícito
+
+---
+
+### Estado A2 — Formateo
 
 ```bash
 mkfs.ext4 /dev/vg0/docker_vol
 ```
 
-**3. Crear un punto de montaje**
+**Propósito**
+
+* Inicializar el bloque con FS controlado
+
+---
+
+### Estado A3 — Preparación del punto de montaje
 
 ```bash
 mkdir -p /mnt/docker_vol
 ```
 
-**4. Montarlo**
+---
+
+### Estado A4 — Montaje
 
 ```bash
 mount /dev/vg0/docker_vol /mnt/docker_vol
 ```
 
-**5. Usarlo como volumen en Docker**
+**Señal observable**
+
+```bash
+df -h /mnt/docker_vol
+```
+
+Debe mostrar **exactamente 5G**.
+
+---
+
+### Estado A5 — Uso en Docker
 
 ```bash
 docker run -v /mnt/docker_vol:/data imagen
 ```
 
-Resultado: el directorio `/data` dentro del contenedor **no puede superar 5 GB**, porque el volumen lógico aplicado al host lo limita de forma estricta.
+**Garantía**
+
+* El contenedor no puede exceder 5 GB bajo ninguna circunstancia.
 
 ---
 
-## 2. Con **archivo `.img` tipo loop** (sin particiones reales)
+## 7) Flujo de ejecución — Opción B: **Archivo `.img` en loop**
 
-Esto es útil si no quieres tocar LVM ni crear particiones.
-Crea un archivo que actúa como disco virtual.
-
-### Pasos
-
-**1. Crear archivo con tamaño fijo**
+### Estado B1 — Creación del archivo-disco
 
 ```bash
 truncate -s 5G /opt/docker_vol.img
 ```
 
-**2. Formatearlo**
+**Propósito**
+
+* Definir límite físico desde el inicio
+
+---
+
+### Estado B2 — Formateo del archivo
 
 ```bash
 mkfs.ext4 /opt/docker_vol.img
 ```
 
-**3. Montarlo usando loop**
+---
+
+### Estado B3 — Preparación del punto de montaje
 
 ```bash
 mkdir -p /mnt/docker_vol
-mount -o loop docker_vol.img /mnt/docker_vol
-umount /mnt/docker_vol
-sudo losetup -D
 ```
 
-**4. Usarlo en Docker**
+---
+
+### Estado B4 — Montaje por loop
+
+```bash
+mount -o loop /opt/docker_vol.img /mnt/docker_vol
+```
+
+**Verificación**
+
+```bash
+df -h /mnt/docker_vol
+```
+
+Debe reflejar **5G exactos**.
+
+---
+
+### Estado B5 — Uso en Docker
 
 ```bash
 docker run --rm -it -v /mnt/docker_vol:/opt/data alpine:3.20 sh
 df -h /opt/data
 ```
 
-El límite lo impone el tamaño del archivo `.img`.
+**Resultado**
+
+* Límite impuesto por el tamaño del `.img`.
+
+---
+
+### Estado B6 — Desmontaje y limpieza (opcional)
+
+```bash
+umount /mnt/docker_vol
+losetup -D
+```
+
+---
+
+## 8) Control de calidad (postcondiciones)
+
+Validar siempre:
+
+* `df -h` refleja el tamaño esperado
+* Escrituras fallan al alcanzar el límite (ENOSPC)
+* Docker no sobrepasa el cap
+* No hay mounts huérfanos
+
+---
+
+## 9) Diagnóstico rápido (troubleshooting)
+
+| Síntoma                    | Causa probable                   | Acción             |
+| -------------------------- | -------------------------------- | ------------------ |
+| Docker ignora el límite    | Volumen no montado correctamente | Revisar `mount`    |
+| Tamaño incorrecto          | Error en `truncate` o `lvcreate` | Re-crear           |
+| `device busy` al desmontar | Contenedor activo                | Detener contenedor |
+| Bajo rendimiento           | Loop FS                          | Preferir LVM       |
+
+---
+
+## 10) Procedimiento compacto (referencia rápida)
+
+**LVM**
+
+1. `lvcreate -L 5G`
+2. `mkfs.ext4`
+3. `mount`
+4. `docker -v`
+
+**IMG**
+
+1. `truncate -s 5G`
+2. `mkfs.ext4`
+3. `mount -o loop`
+4. `docker -v`
+
+---
+
+## 11) Conclusión operativa
+
+* **LVM** → producción, control fuerte, menor portabilidad.
+* **`.img` loop** → portable, simple, autocontenido.
+
+Ambos cumplen el objetivo; la elección depende del **contexto operativo**, no de preferencia personal.

--- a/backup/docker-compose.yml
+++ b/backup/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.5'
 services:
   backup:
     container_name: backup

--- a/cuda/docker-compose.yml
+++ b/cuda/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.5'
 services:
   cuda-11:
     image: cuda:local-11

--- a/database/mongo/docker-compose.yml
+++ b/database/mongo/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.5'
 services:
   mongodb:
     image: mongo:8.0

--- a/database/postgresql/README.md
+++ b/database/postgresql/README.md
@@ -2,5 +2,5 @@
 
 psql -U postgres_shared -d postgres
 CREATE DATABASE coder;
-CREATE DATABASE docmost;
 CREATE DATABASE penpot;
+CREATE DATABASE teable;

--- a/network/Dockerfile
+++ b/network/Dockerfile
@@ -5,3 +5,4 @@ RUN apk add --no-cache \
     nftables \
     && rm -rf /var/cache/apk/*
 
+COPY /conf/nftables.nft /etc/nftables.nft

--- a/network/Dockerfile
+++ b/network/Dockerfile
@@ -2,7 +2,7 @@ ARG alpine_ver=3.20
 FROM alpine:${alpine_ver}
 
 RUN apk add --no-cache \
-    nftables \
+    nftables openssh-server \
     && rm -rf /var/cache/apk/*
 
 COPY /conf/nftables.nft /etc/nftables.nft

--- a/network/docker-compose.yml
+++ b/network/docker-compose.yml
@@ -12,6 +12,8 @@ services:
   network:
     container_name: network-system
     image: router:v0.1
+    cap_add:
+      - NET_ADMIN
     build:
       context: .
       dockerfile: Dockerfile

--- a/os/ubuntu/base/Dockerfile
+++ b/os/ubuntu/base/Dockerfile
@@ -30,7 +30,7 @@ RUN mkdir -p /var/run/sshd && \
 
 # App installation
 RUN if [ "$app_essentials" = "true" ]; then \
-    apt-get update && apt-get install -y build-essential curl nano git wget htop \
+    apt-get update && apt-get install -y build-essential curl nano git git-lfs wget htop \
     && apt-get clean && rm -rf /var/lib/apt/lists/*; \
     echo "App essentials installed."; \
     else \
@@ -63,9 +63,7 @@ COPY --from=entrydata /entrypoint/start-dockerd.sh /usr/local/bin/start-dockerd.
 COPY supervisord.conf /etc/supervisord.conf
 
 # Configure
-RUN chmod +x /usr/local/bin/create-user.sh
 RUN chmod +x /usr/local/bin/start-dockerd.sh
 
 # Run
-ENTRYPOINT [ "/usr/local/bin/create-user.sh" ]
 CMD [ "supervisord", "-c", "/etc/supervisord.conf" ]

--- a/service/metabase/docker-compose.yml
+++ b/service/metabase/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.5'
 services:
   metabase:
     image: metabase/metabase:v0.54.3.2

--- a/service/teable/docker-compose.yml
+++ b/service/teable/docker-compose.yml
@@ -1,79 +1,27 @@
 services:
   teable:
     image: ghcr.io/teableio/teable:0.5.0-alpha-1.10.0-build.600-amd64
-    restart: always
+    restart: unless-stopped
+    container_name: teable
     ports:
       - 3045:3000
     volumes:
-      - teable-data:/app/.assets:rw
-    env_file:
-      - .env
+      - data:/app/.assets:rw
     environment:
       - NEXT_ENV_IMAGES_ALL_REMOTE=true
+      - SECRET_KEY=replace_this_secret_key
+      - PUBLIC_ORIGIN=http://127.0.0.1:3000
+      - PRISMA_DATABASE_URL=postgresql://postgres_shared:postgres_shared@10.10.3.153:5432/teable
+      - BACKEND_CACHE_PROVIDER=redis
+      - BACKEND_CACHE_REDIS_URI=redis://default@10.10.3.143:6379/0
     networks:
       network_service:
-        ipv4_address: 10.10.3.28
-      teable-network:
-        ipv4_address: 178.18.0.25
-    depends_on:
-      teable-db:
-        condition: service_healthy
-      teable-cache:
-        condition: service_healthy
-    healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:3000/health']
-      start_period: 5s
-      interval: 5s
-      timeout: 3s
-      retries: 3
-
-  teable-db:
-    image: postgres:15.4
-    restart: always
-    ports:
-      - '42345:5432'
-    volumes:
-      - teable-db:/var/lib/postgresql/data:rw
-    environment:
-      - POSTGRES_DB=${POSTGRES_DB}
-      - POSTGRES_USER=${POSTGRES_USER}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-    networks:
-      teable-network:
-        ipv4_address: 178.18.0.26
-    healthcheck:
-      test: ['CMD-SHELL', "sh -c 'pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}'"]
-      interval: 10s
-      timeout: 3s
-      retries: 3
-
-  teable-cache:
-    image: redis:7.2.4
-    restart: always
-    expose:
-      - '6379'
-    volumes:
-      - teable-cache:/data:rw
-    networks:
-      teable-network:
-        ipv4_address: 178.18.0.27
-    command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD}
-    healthcheck:
-      test: ['CMD', 'redis-cli', '--raw', 'incr', 'ping']
-      interval: 10s
-      timeout: 3s
-      retries: 3
+        ipv4_address: 10.10.3.28 #3000
 
 networks:
   network_service:
     external: true
-  teable-network:
-    driver: bridge
-    ipam:
-      config:
-        - subnet: 178.18.0.0/16
 
 volumes:
-  teable-db: {}
-  teable-data: {}
-  teable-cache: {}
+  data:
+    external: false

--- a/storage/workspace/Dockerfile
+++ b/storage/workspace/Dockerfile
@@ -1,0 +1,4 @@
+ARG alpine_ver=3.20
+FROM alpine:${alpine_ver}
+
+RUN apk add --no-cache git git-lfs && rm -rf /var/cache/apk/*

--- a/storage/workspace/Dockerfile
+++ b/storage/workspace/Dockerfile
@@ -1,4 +1,0 @@
-ARG alpine_ver=3.20
-FROM alpine:${alpine_ver}
-
-RUN apk add --no-cache git git-lfs && rm -rf /var/cache/apk/*

--- a/storage/workspace/docker-compose.yml
+++ b/storage/workspace/docker-compose.yml
@@ -1,9 +1,6 @@
 services:
   workspace:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    image: workspace:local
+    image: alpine:3.20
     container_name: workspace_maintainer
     restart: unless-stopped
     command: tail -f /dev/null

--- a/storage/workspace/docker-compose.yml
+++ b/storage/workspace/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   workspace:
-    image: alpine:3.20
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: workspace:local
     container_name: workspace_maintainer
     restart: unless-stopped
     command: tail -f /dev/null

--- a/user/README.md
+++ b/user/README.md
@@ -38,3 +38,20 @@ This container creates a non-root user defined via environment variables (UID/GI
 * Shared space with other services or containers (`/home/shared`)
 * Communication with the Docker daemon via its socket (`/var/run/docker.sock`)
 * Access to host-mounted directories or physical disks (`/mnt`)
+
+3. Configuración del servidor SSH
+
+En el servidor / contenedor, edita:
+
+/etc/ssh/sshd_config
+
+
+Asegúrate de tener:
+
+AllowAgentForwarding yes
+PubkeyAuthentication yes
+
+
+Reinicia SSH:
+
+service ssh restart

--- a/user/docker-compose.yml
+++ b/user/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   maintainer:
     image: maintainer:local
     container_name: maintainer
+    restart: unless-stopped
     build:
       context: .
       dockerfile: Dockerfile
@@ -11,6 +12,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - /mnt:/mnt # disk mount from host
       - shared:/home/shared
+      - $SSH_AUTH_SOCK:/ssh-agent
     networks:
       network_user:
         ipv4_address: 10.10.4.18

--- a/user/docker-compose.yml
+++ b/user/docker-compose.yml
@@ -5,20 +5,26 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    environment:
-      - USERNAME=maintainer
     volumes:
-      - maintainer:/home/maintainer
-      - ubuntu_user_shared:/home/shared
+      - data:/home/${USERNAME}
+      - etc:/etc
       - /var/run/docker.sock:/var/run/docker.sock
       - /mnt:/mnt # disk mount from host
+      - shared:/home/shared
+    networks:
+      network_user:
+        ipv4_address: 10.10.4.18
     group_add:
       - "998"
 
-volumes:
-  maintainer:
-    external: false
-
-  # ubuntu_ this created for compose
-  ubuntu_user_shared:
+networks:
+  network_user:
     external: true
+
+volumes:
+  data:
+    external: false
+  etc:
+    external: false
+  shared:
+    external: false


### PR DESCRIPTION
This pull request introduces several infrastructure and configuration improvements across multiple services and documentation. The main themes are: simplifying and standardizing Docker Compose files, updating service configurations (notably for Teable and user management), enhancing network and security setup, and providing new operational documentation for portable storage with strict size limits.

**Service and Compose Configuration Updates:**

* Removed the `version` field from multiple `docker-compose.yml` files for consistency and to align with modern Compose best practices. (`app/conda/docker-compose.yml` [[1]](diffhunk://#diff-8c9d63513e9d40a92cf3b8bf36e2921a093577a62885f5896f08a26650b063e2L1) `app/julia/docker-compose.yml` [[2]](diffhunk://#diff-7e9c8b5412eed5b1cc3c6821a244cc54beed4b496413af273e3272e7e4b25584L1) `backup/docker-compose.yml` [[3]](diffhunk://#diff-b6d998ac959cb581c34a56a689f3e39128a79ff86d5ce2392c858ba646dda3e9L1) `cuda/docker-compose.yml` [[4]](diffhunk://#diff-731fa9c0aa26248926a9d6b653fb7f736cba5be8ea6bdd32e3a9eb2c4fbc0722L1) `database/mongo/docker-compose.yml` [[5]](diffhunk://#diff-3f512869a3c3a28e87ec414bbe217ec1a4d1e6065ff4f6a97b4b9329689af27eL1) `service/metabase/docker-compose.yml` [[6]](diffhunk://#diff-c846be494955fdb8270425f941b2bf05085938d8ffba7f311b82ff2a24db8d43L1)
* Major refactor of the Teable service definition: simplified the stack to a single service, switched to an external Postgres and Redis, added explicit environment variables, changed volume and network configuration, and removed internal healthchecks and dependencies. (`service/teable/docker-compose.yml` [service/teable/docker-compose.ymlL4-R27](diffhunk://#diff-0491809da8d84355a16cc1358859bf374b3df07e0c7f25640b14fc5ca75f6ed1L4-R27))
* Updated the user service Compose file to use more descriptive and flexible volume names, added SSH agent forwarding, and improved network configuration. (`user/docker-compose.yml` [user/docker-compose.ymlR5-L24](diffhunk://#diff-553704e44001c1d5920e998a144570582f9012895fd476b1ceb9f84a42715c6bR5-L24))

**Documentation and Operational Guidance:**

* Added a comprehensive Spanish-language guide to portable storage with strict size limits, comparing LVM and loop-mounted `.img` files, including setup, usage, troubleshooting, and quick reference procedures. (`backup/README.md` [backup/README.mdR1-R279](diffhunk://#diff-69b4b92f637e7adc6c4dd35b51d75188e388ee170c5e015ca99c6ed0e31d3eb6R1-R279))
* Updated the user service documentation to include SSH server configuration instructions for agent forwarding and public key authentication. (`user/README.md` [user/README.mdR41-R57](diffhunk://#diff-da2e6bbac4e009ba3101274dda1a244d0229e746a679db65ede2f6a6e558dbc6R41-R57))

**Network and Security Enhancements:**

* In the network Dockerfile, added `openssh-server` to the image, and now copy a default `nftables.nft` configuration file into the image. (`network/Dockerfile` [network/DockerfileL5-R8](diffhunk://#diff-6ca29fa4176053334a2ee6c95db945c2fdb62341bdd031e21e649cffe4be3a53L5-R8))
* Updated the network Compose file to grant the container `NET_ADMIN` capabilities, enabling advanced networking features. (`network/docker-compose.yml` [network/docker-compose.ymlR15-R16](diffhunk://#diff-3374b09b0b0e9b25600bc9682ddd2c91ff97e7d1ef43524feb7bb531010ed7f3R15-R16))

**Other Notable Changes:**

* Updated the Ubuntu base Dockerfile to install `git-lfs` alongside `git` when app essentials are enabled, and removed an unnecessary `chmod` command. (`os/ubuntu/base/Dockerfile` [[1]](diffhunk://#diff-2bf492b25ce94d4704f1102325067da6341e522a016cb41ba5ec3c34237399f1L33-R33) [[2]](diffhunk://#diff-2bf492b25ce94d4704f1102325067da6341e522a016cb41ba5ec3c34237399f1L66-L70)
* Updated Postgres database initialization instructions: removed the creation of the `docmost` database and added `teable` instead. (`database/postgresql/README.md` [database/postgresql/README.mdL5-R6](diffhunk://#diff-98ab5d52307e64d352706938d327def041281521cf6f9a560f0897d676dc1defL5-R6))